### PR TITLE
Add environment setup instructions to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
 # News API
+
+## Environment Setup
+
+In order to create and connect to the databases locally you will need to make two environment files. These need to be created at the root of the repository and will set your PGDATABASE environment variable for the appropriate database:
+
+- .env.development
+
+```
+PGDATABASE=nc_news
+```
+
+- .env.test
+
+```
+PGDATABASE=nc_news_test
+```
+
+Both of these files are already included in the .gitignore and will not be tracked.


### PR DESCRIPTION
Added a section to the README file regarding the creation of the two .env files required for creating and connecting to the databases locally.