### PR TITLE
Add /api/articles endpoint

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -134,4 +134,30 @@ describe("app", () => {
       });
     });
   });
+
+  describe("/api/articles", () => {
+    describe("GET", () => {
+      test("Status 200 - responds with an object containing a key of articles with a value of an array of article objects sorted by date (created_at) in descending order", () => {
+        return request(app)
+          .get("/api/articles")
+          .expect(200)
+          .then(({ body: { articles } }) => {
+            expect(articles).toHaveLength(12);
+            expect(articles).toBeSortedBy("created_at", { descending: true });
+            articles.forEach((article) => {
+              expect(article).toEqual(
+                expect.objectContaining({
+                  author: expect.any(String),
+                  title: expect.any(String),
+                  article_id: expect.any(Number),
+                  topic: expect.any(String),
+                  created_at: expect.any(String),
+                  votes: expect.any(Number),
+                })
+              );
+            });
+          });
+      });
+    });
+  });
 });

--- a/app.js
+++ b/app.js
@@ -4,6 +4,7 @@ const { getTopics } = require("./controllers/topics.controllers");
 const {
   getArticleById,
   patchArticleById,
+  getArticles,
 } = require("./controllers/articles.controllers");
 
 const {
@@ -20,6 +21,7 @@ app.use(express.json());
 app.get("/api/topics", getTopics);
 app.get("/api/articles/:article_id", getArticleById);
 app.patch("/api/articles/:article_id", patchArticleById);
+app.get("/api/articles", getArticles);
 
 app.all("/*", handleInvalidEndpoint);
 

--- a/controllers/articles.controllers.js
+++ b/controllers/articles.controllers.js
@@ -1,6 +1,7 @@
 const {
   selectArticleById,
   updateArticleById,
+  selectArticles,
 } = require("../models/articles.models");
 
 exports.getArticleById = (req, res, next) => {
@@ -18,6 +19,14 @@ exports.patchArticleById = (req, res, next) => {
   updateArticleById(articleId, incVotes)
     .then((article) => {
       res.status(200).send({ article });
+    })
+    .catch(next);
+};
+
+exports.getArticles = (_, res, next) => {
+  selectArticles()
+    .then((articles) => {
+      res.status(200).send({ articles });
     })
     .catch(next);
 };

--- a/models/articles.models.js
+++ b/models/articles.models.js
@@ -28,3 +28,9 @@ exports.updateArticleById = (articleId, incVotes) => {
       return article;
     });
 };
+
+exports.selectArticles = () => {
+  return db
+    .query("SELECT * FROM articles ORDER BY created_at DESC;")
+    .then(({ rows: articles }) => articles);
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "husky": "^7.0.0",
         "jest": "^27.5.1",
         "jest-extended": "^2.0.0",
+        "jest-sorted": "^1.0.14",
         "pg-format": "^1.0.4",
         "supertest": "^6.2.2"
       }
@@ -3141,6 +3142,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/jest-sorted": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/jest-sorted/-/jest-sorted-1.0.14.tgz",
+      "integrity": "sha512-qGMA3ybF15S+4gDtv3XaE/GtEd3YvSepVC3vL63TbxIISkeOS/0HhRZYL12VQGKn0TWyi2/62dh5OO71X9LY3A==",
+      "dev": true
     },
     "node_modules/jest-util": {
       "version": "27.5.1",
@@ -7381,6 +7388,12 @@
           }
         }
       }
+    },
+    "jest-sorted": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/jest-sorted/-/jest-sorted-1.0.14.tgz",
+      "integrity": "sha512-qGMA3ybF15S+4gDtv3XaE/GtEd3YvSepVC3vL63TbxIISkeOS/0HhRZYL12VQGKn0TWyi2/62dh5OO71X9LY3A==",
+      "dev": true
     },
     "jest-util": {
       "version": "27.5.1",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "husky": "^7.0.0",
     "jest": "^27.5.1",
     "jest-extended": "^2.0.0",
+    "jest-sorted": "^1.0.14",
     "pg-format": "^1.0.4",
     "supertest": "^6.2.2"
   },
@@ -34,7 +35,8 @@
   },
   "jest": {
     "setupFilesAfterEnv": [
-      "jest-extended/all"
+      "jest-extended/all",
+      "jest-sorted"
     ]
   }
 }


### PR DESCRIPTION
Adds jest-sorted to the package files in order to test that the articles in the response are in descending order according to their created_on value. The only relevant error needing to be handled is a 404 which has been handled for all invalid endpoints previously.