### PR TITLE
Add GET /api/articles/:article_id/comments endpoint

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -178,4 +178,28 @@ describe("app", () => {
       });
     });
   });
+
+  describe("/api/articles/:article_id/comments", () => {
+    describe.only("GET", () => {
+      test("Status 200 - responds with an object with a key of comments and a value of an array of comment objects associated with the requested article_id", () => {
+        return request(app)
+          .get("/api/articles/9/comments")
+          .expect(200)
+          .then(({ body: { comments } }) => {
+            expect(comments).toHaveLength(2);
+            comments.forEach((comment) => {
+              expect(comment).toEqual(
+                expect.objectContaining({
+                  comment_id: expect.any(Number),
+                  votes: expect.any(Number),
+                  created_at: expect.any(String),
+                  author: expect.any(String),
+                  body: expect.any(String),
+                })
+              );
+            });
+          });
+      });
+    });
+  });
 });

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -21,32 +21,6 @@ describe("app", () => {
     });
   });
 
-  describe("utilities", () => {
-    describe("checkExists", () => {
-      test("Returns a fulfilled promise (value of undefined) when value argument does exist within the argument table under the argument column", () => {
-        return checkExists(
-          "comments",
-          "article_id",
-          1,
-          "error message argument"
-        ).then((response) => {
-          expect(response).toBe(undefined);
-        });
-      });
-      test("Returns rejected promise with a value of an error object (404, custom message) if value argument doesn't exist in the argument table under the argument column", () => {
-        return checkExists(
-          "comments",
-          "article_id",
-          2,
-          "error message argument"
-        ).catch((err) => {
-          expect(err.status).toBe(404);
-          expect(err.msg).toBe("error message argument");
-        });
-      });
-    });
-  });
-
   describe("/api/topics", () => {
     describe("GET", () => {
       test("Status 200 - responds with an object with a key of topics with a value of an array of objects each with a 'slug' and 'description' property", () => {

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -1,4 +1,5 @@
 const app = require("../app");
+const { checkExists } = require("../db/helpers/utils");
 const db = require("../db/connection");
 const data = require("../db/data");
 const seed = require("../db/seeds/seed");
@@ -19,6 +20,33 @@ describe("app", () => {
         });
     });
   });
+
+  describe("utilities", () => {
+    describe("checkExists", () => {
+      test("Returns a fulfilled promise (value of undefined) when value argument does exist within the argument table under the argument column", () => {
+        return checkExists(
+          "comments",
+          "article_id",
+          1,
+          "error message argument"
+        ).then((response) => {
+          expect(response).toBe(undefined);
+        });
+      });
+      test("Returns rejected promise with a value of an error object (404, custom message) if value argument doesn't exist in the argument table under the argument column", () => {
+        return checkExists(
+          "comments",
+          "article_id",
+          2,
+          "error message argument"
+        ).catch((err) => {
+          expect(err.status).toBe(404);
+          expect(err.msg).toBe("error message argument");
+        });
+      });
+    });
+  });
+
   describe("/api/topics", () => {
     describe("GET", () => {
       test("Status 200 - responds with an object with a key of topics with a value of an array of objects each with a 'slug' and 'description' property", () => {

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -180,7 +180,7 @@ describe("app", () => {
   });
 
   describe("/api/articles/:article_id/comments", () => {
-    describe.only("GET", () => {
+    describe("GET", () => {
       test("Status 200 - responds with an object with a key of comments and a value of an array of comment objects associated with the requested article_id", () => {
         return request(app)
           .get("/api/articles/9/comments")
@@ -198,6 +198,30 @@ describe("app", () => {
                 })
               );
             });
+          });
+      });
+      test("Status 200 - responds with empty array if article is valid, exists in the database but doesn't have any comments associated with it", () => {
+        return request(app)
+          .get("/api/articles/2/comments")
+          .expect(200)
+          .then(({ body: { comments } }) => {
+            expect(comments).toEqual([]);
+          });
+      });
+      test("Status 404 - responds with msg 'No article matching requested id' when article_id is valid but there isn't an article with that id currently in the database", () => {
+        return request(app)
+          .get("/api/articles/9999/comments")
+          .expect(404)
+          .then(({ body: { msg } }) => {
+            expect(msg).toBe("No article matching requested id");
+          });
+      });
+      test("Status 400 - responds with 'Bad request' if requested article_id isn't an integer", () => {
+        return request(app)
+          .get("/api/articles/not-an-int/comments")
+          .expect(400)
+          .then(({ body: { msg } }) => {
+            expect(msg).toBe("Bad request");
           });
       });
     });

--- a/__tests__/utils.test.js
+++ b/__tests__/utils.test.js
@@ -1,7 +1,10 @@
+const db = require("../db/connection");
+
 const {
   convertTimestampToDate,
   createRef,
   formatComments,
+  checkExists,
 } = require("../db/helpers/utils");
 
 describe("convertTimestampToDate", () => {
@@ -100,5 +103,30 @@ describe("formatComments", () => {
     const comments = [{ created_at: timestamp }];
     const formattedComments = formatComments(comments, {});
     expect(formattedComments[0].created_at).toEqual(new Date(timestamp));
+  });
+});
+
+describe("checkExists", () => {
+  afterAll(() => db.end());
+  test("Returns a fulfilled promise (value of undefined) when value argument does exist within the argument table under the argument column", () => {
+    return checkExists(
+      "comments",
+      "article_id",
+      1,
+      "error message argument"
+    ).then((response) => {
+      expect(response).toBe(undefined);
+    });
+  });
+  test("Returns rejected promise with a value of an error object (404, custom message) if value argument doesn't exist in the argument table under the argument column", () => {
+    return checkExists(
+      "comments",
+      "article_id",
+      2,
+      "error message argument"
+    ).catch((err) => {
+      expect(err.status).toBe(404);
+      expect(err.msg).toBe("error message argument");
+    });
   });
 });

--- a/app.js
+++ b/app.js
@@ -7,6 +7,9 @@ const {
   getArticles,
 } = require("./controllers/articles.controllers");
 const { getUsers } = require("./controllers/users.controllers");
+const {
+  getCommentsByArticleId,
+} = require("./controllers/comments.controllers");
 
 const {
   handleInvalidEndpoint,
@@ -24,6 +27,7 @@ app.get("/api/articles/:article_id", getArticleById);
 app.patch("/api/articles/:article_id", patchArticleById);
 app.get("/api/users", getUsers);
 app.get("/api/articles", getArticles);
+app.get("/api/articles/:article_id/comments", getCommentsByArticleId);
 
 app.all("/*", handleInvalidEndpoint);
 

--- a/controllers/comments.controllers.js
+++ b/controllers/comments.controllers.js
@@ -1,0 +1,10 @@
+const { selectCommentsByArticleId } = require("../models/comments.models");
+
+exports.getCommentsByArticleId = (req, res, next) => {
+  const articleId = req.params.article_id;
+  selectCommentsByArticleId(articleId)
+    .then((comments) => {
+      res.status(200).send({ comments });
+    })
+    .catch(console.log);
+};

--- a/controllers/comments.controllers.js
+++ b/controllers/comments.controllers.js
@@ -1,10 +1,20 @@
 const { selectCommentsByArticleId } = require("../models/comments.models");
+const { checkExists } = require("../db/helpers/utils");
 
 exports.getCommentsByArticleId = (req, res, next) => {
   const articleId = req.params.article_id;
-  selectCommentsByArticleId(articleId)
+  const idExists = checkExists(
+    "articles",
+    "article_id",
+    articleId,
+    "No article matching requested id"
+  );
+  return Promise.all([articleId, idExists])
+    .then(([articleId]) => {
+      return selectCommentsByArticleId(articleId);
+    })
     .then((comments) => {
       res.status(200).send({ comments });
     })
-    .catch(console.log);
+    .catch(next);
 };

--- a/models/comments.models.js
+++ b/models/comments.models.js
@@ -1,5 +1,4 @@
 const db = require("../db/connection");
-const { checkExists } = require("../db/helpers/utils");
 
 exports.selectCommentsByArticleId = (articleId) => {
   return db

--- a/models/comments.models.js
+++ b/models/comments.models.js
@@ -1,0 +1,14 @@
+const db = require("../db/connection");
+
+exports.selectCommentsByArticleId = (articleId) => {
+  return db
+    .query(
+      `
+  SELECT comment_id, votes, created_at, author, body
+  FROM comments
+  WHERE article_id = $1
+    `,
+      [articleId]
+    )
+    .then(({ rows: comments }) => comments);
+};

--- a/models/comments.models.js
+++ b/models/comments.models.js
@@ -1,4 +1,5 @@
 const db = require("../db/connection");
+const { checkExists } = require("../db/helpers/utils");
 
 exports.selectCommentsByArticleId = (articleId) => {
   return db

--- a/models/comments.models.js
+++ b/models/comments.models.js
@@ -6,7 +6,7 @@ exports.selectCommentsByArticleId = (articleId) => {
       `
   SELECT comment_id, votes, created_at, author, body
   FROM comments
-  WHERE article_id = $1
+  WHERE article_id = $1;
     `,
       [articleId]
     )


### PR DESCRIPTION
As part of this endpoint a checkExists utility function was created to differentiate between requests for valid ids that didn't exist in the database and article_ids for articles with no associated comments.