### PR TITLE
Add comment_count feature to GET /api/articles

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -192,6 +192,17 @@ describe("app", () => {
             });
           });
       });
+      test("Status 200 - article objects have a comment_count property (integer corresponding to the number of comments associated with the article)", () => {
+        return request(app)
+          .get("/api/articles")
+          .expect(200)
+          .then(({ body: { articles } }) => {
+            articles.forEach((article) => {
+              expect(typeof article.comment_count).toBe("number");
+              if (article.id === 2) expect(article.comment_count).toBe(0);
+            });
+          });
+      });
     });
   });
 });

--- a/models/articles.models.js
+++ b/models/articles.models.js
@@ -40,6 +40,14 @@ exports.updateArticleById = (articleId, incVotes) => {
 
 exports.selectArticles = () => {
   return db
-    .query("SELECT * FROM articles ORDER BY created_at DESC;")
+    .query(
+      `
+    SELECT articles.*, COUNT(comments.comment_id)::INT AS comment_count
+    FROM articles
+    LEFT JOIN comments ON articles.article_id = comments.article_id
+    GROUP BY articles.article_id
+    ORDER BY created_at DESC;
+      `
+    )
     .then(({ rows: articles }) => articles);
 };


### PR DESCRIPTION
Tested that each article had an integer comment_count property and specifically that the one with an article_id of 2 had a comment count of 0 (to make sure the join included all of the articles).