### PR TITLE
Add queries to /api/articles endpoint

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -205,6 +205,75 @@ describe("app", () => {
             });
           });
       });
+      test("Status 200 - user can decided order with order query - defaults to descending", () => {
+        return request(app)
+          .get("/api/articles?order=asc")
+          .expect(200)
+          .then(({ body: { articles } }) => {
+            expect(articles).toBeSortedBy("created_at");
+          });
+      });
+      test("Status 200 - user can sort by any valid column with the sort_by query", () => {
+        return request(app)
+          .get("/api/articles?sort_by=date")
+          .expect(200)
+          .then(({ body: { articles } }) => {
+            expect(articles).toBeSortedBy("created_at", {
+              descending: true,
+            });
+          });
+      });
+      test("Status 200 - sort_by query works for comment_count", () => {
+        return request(app)
+          .get("/api/articles?sort_by=comment_count")
+          .expect(200)
+          .then(({ body: { articles } }) => {
+            expect(articles).toBeSortedBy("comment_count", {
+              descending: true,
+            });
+          });
+      });
+      test("Status 200 - user can filter by topic with the topic query (exact match only)", () => {
+        return request(app)
+          .get("/api/articles?topic=mitch")
+          .expect(200)
+          .then(({ body: { articles } }) => {
+            expect(articles).toHaveLength(11);
+          });
+      });
+      test("Status 200 - user can combine queries", () => {
+        return request(app)
+          .get("/api/articles?topic=mitch&sort_by=author&order=asc")
+          .expect(200)
+          .then(({ body: { articles } }) => {
+            expect(articles).toHaveLength(11);
+            expect(articles).toBeSortedBy("author");
+          });
+      });
+      test("Status 404 - responds with error object with msg 'No articles found with that topic' when the topic query results in no articles", () => {
+        return request(app)
+          .get("/api/articles?topic=does-not-exist")
+          .expect(404)
+          .then(({ body: { msg } }) => {
+            expect(msg).toBe("No articles found with that topic");
+          });
+      });
+      test("Status 400 - responds with error object with msg 'Invalid order query - use 'asc' or 'desc'' when order query is invalid", () => {
+        return request(app)
+          .get("/api/articles?order=invalid")
+          .expect(400)
+          .then(({ body: { msg } }) => {
+            expect(msg).toBe("Invalid order query - use 'asc' or 'desc'");
+          });
+      });
+      test("Status 400 - responds with error object with msg 'Invalid sort_by query' when sort_by query is invalid", () => {
+        return request(app)
+          .get("/api/articles?sort_by=invalid")
+          .expect(400)
+          .then(({ body: { msg } }) => {
+            expect(msg).toBe("Invalid sort_by query");
+          });
+      });
     });
   });
 

--- a/controllers/articles.controllers.js
+++ b/controllers/articles.controllers.js
@@ -23,8 +23,9 @@ exports.patchArticleById = (req, res, next) => {
     .catch(next);
 };
 
-exports.getArticles = (_, res, next) => {
-  selectArticles()
+exports.getArticles = (req, res, next) => {
+  const { sort_by: sortBy, order, topic } = req.query;
+  selectArticles(sortBy, order, topic)
     .then((articles) => {
       res.status(200).send({ articles });
     })

--- a/models/articles.models.js
+++ b/models/articles.models.js
@@ -38,16 +38,50 @@ exports.updateArticleById = (articleId, incVotes) => {
     });
 };
 
-exports.selectArticles = () => {
-  return db
-    .query(
-      `
+exports.selectArticles = (sortBy, order, topic) => {
+  const validCols = [
+    "author",
+    "title",
+    "article_id",
+    "topic",
+    "votes",
+    "comment_count",
+    "date",
+  ];
+  if (sortBy && !validCols.includes(sortBy))
+    return Promise.reject({ status: 400, msg: "Invalid sort_by query" });
+
+  if (!sortBy || sortBy === "date") sortBy = "created_at";
+
+  if (order && !["asc", "desc"].includes(order))
+    return Promise.reject({
+      status: 400,
+      msg: "Invalid order query - use 'asc' or 'desc'",
+    });
+
+  order = order === "asc" ? "ASC" : "DESC";
+
+  let queryStr = `
     SELECT articles.*, COUNT(comments.comment_id)::INT AS comment_count
     FROM articles
-    LEFT JOIN comments ON articles.article_id = comments.article_id
+    LEFT JOIN comments ON articles.article_id = comments.article_id `;
+
+  prepValues = [];
+  if (topic) {
+    queryStr += `WHERE topic LIKE $1 `;
+    prepValues.push(`${topic}`);
+  }
+
+  queryStr += `
     GROUP BY articles.article_id
-    ORDER BY created_at DESC;
-      `
-    )
-    .then(({ rows: articles }) => articles);
+    ORDER BY ${sortBy} ${order};`;
+
+  return db.query(queryStr, prepValues).then(({ rows: articles }) => {
+    if (!articles.length)
+      return Promise.reject({
+        status: 404,
+        msg: "No articles found with that topic",
+      });
+    return articles;
+  });
 };


### PR DESCRIPTION
Error handling considerations:
- Opted for a 404 with a helpful custom message if the topic query finds no results. Speculatively searching topics seems a reasonable thing to do from a user perspective but a status 200 with a blank array didn't feel as instructive as a 'No articles with that topic' error message.
- 400 if order isn't 'asc' or 'desc' as although I could just run with the default for invalid queries that could lead to the user mistakenly thinking the server wasn't working correctly i.e. they think they have asked for ascending via 'order=ascending' but their results are in descending order.
- 400 for sort_by not being valid. Custom message but one that doesn't detail what columns exist.