### PR TITLE
Add DELETE /api/comments/:comment_id endpoint

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -318,4 +318,39 @@ describe("app", () => {
       });
     });
   });
+
+  describe("/api/comments/:comment_id", () => {
+    describe("DELETE", () => {
+      test("Status 204 - no response sent back", () => {
+        return request(app)
+          .delete("/api/comments/2")
+          .expect(204)
+          .then(({ body }) => {
+            expect(body).toEqual({});
+            return request(app)
+              .get("/api/articles/1/comments")
+              .expect(200)
+              .then(({ body: { comments } }) => {
+                expect(comments).toHaveLength(10);
+              });
+          });
+      });
+      test("404 - responds with msg 'No comment matching requested id' when comment_id is valid but not currently in the database", () => {
+        return request(app)
+          .delete("/api/comments/999")
+          .expect(404)
+          .then(({ body: { msg } }) => {
+            expect(msg).toBe("No comment matching requested id");
+          });
+      });
+      test("400 - responds with 'Bad request' if requested comment_id isn't an integer", () => {
+        return request(app)
+          .delete("/api/comments/not-an-int")
+          .expect(400)
+          .then(({ body: { msg } }) => {
+            expect(msg).toBe("Bad request");
+          });
+      });
+    });
+  });
 });

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -325,8 +325,7 @@ describe("app", () => {
         return request(app)
           .delete("/api/comments/2")
           .expect(204)
-          .then(({ body }) => {
-            expect(body).toEqual({});
+          .then(() => {
             return request(app)
               .get("/api/articles/1/comments")
               .expect(200)

--- a/app.js
+++ b/app.js
@@ -10,6 +10,7 @@ const { getUsers } = require("./controllers/users.controllers");
 const {
   getCommentsByArticleId,
   postCommentByArticleId,
+  removeCommentById,
 } = require("./controllers/comments.controllers");
 
 const {
@@ -30,6 +31,7 @@ app.get("/api/users", getUsers);
 app.get("/api/articles", getArticles);
 app.get("/api/articles/:article_id/comments", getCommentsByArticleId);
 app.post("/api/articles/:article_id/comments", postCommentByArticleId);
+app.delete("/api/comments/:comment_id", removeCommentById);
 
 app.all("/*", handleInvalidEndpoint);
 

--- a/controllers/comments.controllers.js
+++ b/controllers/comments.controllers.js
@@ -1,6 +1,7 @@
 const {
   selectCommentsByArticleId,
   insertCommentByArticleId,
+  deleteCommentById,
 } = require("../models/comments.models");
 const { checkExists } = require("../db/helpers/utils");
 
@@ -39,5 +40,22 @@ exports.postCommentByArticleId = (req, res, next) => {
     .then((comment) => {
       res.status(201).send({ comment });
     })
+    .catch(next);
+};
+
+exports.removeCommentById = (req, res, next) => {
+  const { comment_id: commentId } = req.params;
+
+  const idExists = checkExists(
+    "comments",
+    "comment_id",
+    commentId,
+    "No comment matching requested id"
+  );
+  return Promise.all([commentId, idExists])
+    .then(([commentId]) => {
+      return deleteCommentById(commentId);
+    })
+    .then(() => res.status(204).send())
     .catch(next);
 };

--- a/controllers/comments.controllers.js
+++ b/controllers/comments.controllers.js
@@ -45,17 +45,14 @@ exports.postCommentByArticleId = (req, res, next) => {
 
 exports.removeCommentById = (req, res, next) => {
   const { comment_id: commentId } = req.params;
-
-  const idExists = checkExists(
-    "comments",
-    "comment_id",
-    commentId,
-    "No comment matching requested id"
-  );
-  return Promise.all([commentId, idExists])
-    .then(([commentId]) => {
-      return deleteCommentById(commentId);
+  return deleteCommentById(commentId)
+    .then((comment) => {
+      if (!comment)
+        return Promise.reject({
+          status: 404,
+          msg: "No comment matching requested id",
+        });
+      return res.status(204).send();
     })
-    .then(() => res.status(204).send())
     .catch(next);
 };

--- a/models/comments.models.js
+++ b/models/comments.models.js
@@ -29,5 +29,5 @@ exports.insertCommentByArticleId = (articleId, newComment) => {
 };
 
 exports.deleteCommentById = (commentId) => {
-  return db.query("DELETE FROM comments WHERE comment_id = $1", [commentId]);
+  return db.query("DELETE FROM comments WHERE comment_id = $1;", [commentId]);
 };

--- a/models/comments.models.js
+++ b/models/comments.models.js
@@ -27,3 +27,7 @@ exports.insertCommentByArticleId = (articleId, newComment) => {
     )
     .then(({ rows: [comment] }) => comment);
 };
+
+exports.deleteCommentById = (commentId) => {
+  return db.query("DELETE FROM comments WHERE comment_id = $1", [commentId]);
+};

--- a/models/comments.models.js
+++ b/models/comments.models.js
@@ -29,5 +29,9 @@ exports.insertCommentByArticleId = (articleId, newComment) => {
 };
 
 exports.deleteCommentById = (commentId) => {
-  return db.query("DELETE FROM comments WHERE comment_id = $1;", [commentId]);
+  return db
+    .query("DELETE FROM comments WHERE comment_id = $1 RETURNING *;", [
+      commentId,
+    ])
+    .then(({ rows: [comment] }) => comment);
 };


### PR DESCRIPTION
Tested that the deletion had occurred by querying the database after and expecting how many comments should still remain for the article. Couldn't see any other way of testing that the deletion had happened but this felt a little questionable to me - using a different endpoint to test this one. Is this the right way to test it or do you just assume that if the request is a success and you've handled the possible errors that a 204 is enough validation?